### PR TITLE
Implemented examples building support

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -37,7 +37,7 @@ jobs:
         mkdir build
     - name: Building with CMake
       run: |
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=ON
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_EXAMPLES:BOOL=ON
         cmake --build build
     - name: Installing project
       run: |

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -34,7 +34,7 @@ jobs:
         mkdir build
     - name: Building with CMake
       run: |
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=ON
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_EXAMPLES:BOOL=ON
         cmake --build build
     - name: Installing project
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(GNUInstallDirs)
 
-# ================
-# === C target ===
-# ================
+# ========================
+# === C library target ===
+# ========================
 
 set(QRCODEGEN_SOURCES
     c/qrcodegen.c
@@ -54,9 +54,9 @@ install(TARGETS qrcodegen
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/qrcodegen
 )
 
-# ==================
-# === C++ target ===
-# ==================
+# ==========================
+# === C++ library target ===
+# ==========================
 
 set(QRCODEGENCPP_SOURCES
     cpp/qrcodegen.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,22 @@ install(TARGETS qrcodegen
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/qrcodegen
 )
 
+# =========================
+# === C examples target ===
+# =========================
+
+set(QRCODEGENDEMO_SOURCES
+    c/qrcodegen-demo.c
+)
+
+add_executable(qrcodegen-demo
+    ${QRCODEGENDEMO_SOURCES}
+)
+
+target_link_libraries(qrcodegen-demo PRIVATE
+    qrcodegen
+)
+
 # ==========================
 # === C++ library target ===
 # ==========================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,3 +101,19 @@ install(TARGETS qrcodegencpp
     BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/qrcodegencpp
 )
+
+# ===========================
+# === C++ examples target ===
+# ===========================
+
+set(QRCODEGENCPPDEMO_SOURCES
+    cpp/QrCodeGeneratorDemo.cpp
+)
+
+add_executable(qrcodegencpp-demo
+    ${QRCODEGENCPPDEMO_SOURCES}
+)
+
+target_link_libraries(qrcodegencpp-demo PRIVATE
+    qrcodegencpp
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@
 # SPDX-License-Identifier: MIT
 #
 
+# ==============================
+# === Project initialization ===
+# ==============================
+
 cmake_minimum_required(VERSION 3.12)
 
 project(QR-Code-generator
@@ -15,6 +19,12 @@ project(QR-Code-generator
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# =======================
+# === Project options ===
+# =======================
+
+option(BUILD_EXAMPLES "Build examples and demos" OFF)
 
 # =======================
 # === Paths detection ===
@@ -58,17 +68,19 @@ install(TARGETS qrcodegen
 # === C examples target ===
 # =========================
 
-set(QRCODEGENDEMO_SOURCES
-    c/qrcodegen-demo.c
-)
+if(BUILD_EXAMPLES)
+    set(QRCODEGENDEMO_SOURCES
+        c/qrcodegen-demo.c
+    )
 
-add_executable(qrcodegen-demo
-    ${QRCODEGENDEMO_SOURCES}
-)
+    add_executable(qrcodegen-demo
+        ${QRCODEGENDEMO_SOURCES}
+    )
 
-target_link_libraries(qrcodegen-demo PRIVATE
-    qrcodegen
-)
+    target_link_libraries(qrcodegen-demo PRIVATE
+        qrcodegen
+    )
+endif()
 
 # ==========================
 # === C++ library target ===
@@ -106,14 +118,16 @@ install(TARGETS qrcodegencpp
 # === C++ examples target ===
 # ===========================
 
-set(QRCODEGENCPPDEMO_SOURCES
-    cpp/QrCodeGeneratorDemo.cpp
-)
+if(BUILD_EXAMPLES)
+    set(QRCODEGENCPPDEMO_SOURCES
+        cpp/QrCodeGeneratorDemo.cpp
+    )
 
-add_executable(qrcodegencpp-demo
-    ${QRCODEGENCPPDEMO_SOURCES}
-)
+    add_executable(qrcodegencpp-demo
+        ${QRCODEGENCPPDEMO_SOURCES}
+    )
 
-target_link_libraries(qrcodegencpp-demo PRIVATE
-    qrcodegencpp
-)
+    target_link_libraries(qrcodegencpp-demo PRIVATE
+        qrcodegencpp
+    )
+endif()


### PR DESCRIPTION
Describe your changes below:

Implemented examples building support. Disabled by default. Can be enabled by forwarding a special `-DBUILD_EXAMPLES:BOOL=ON` configuration option.

Closes #3.